### PR TITLE
Set header to null if origin isn't allowed when using an array or regex origin

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -149,6 +149,9 @@
           applyHeaders(header, res);
         } else if (header.key === 'Vary' && header.value) {
           vary(res, header.value);
+        } else if (header.key === 'Access-Control-Allow-Origin' && !header.value) {
+          // Unset the header in case it has already been set (which can happen if you use both an app-wide and per route cors middleware)
+          res.setHeader(header.key, null);
         } else if (header.value) {
           res.setHeader(header.key, header.value);
         }

--- a/test/test.js
+++ b/test/test.js
@@ -260,6 +260,24 @@
         });
       });
 
+      it('doesn\'t match request origin against array of invalid origin checks even if header has already been set', function(done) {
+        var req = fakeRequest('GET');
+        var res = fakeResponse();
+        var options = { origin: [ /foo\.com$/, 'bar.com' ] };
+        cors()(req, res, function(err) {
+          assert.ifError(err)
+          assert.equal(res.getHeader('Access-Control-Allow-Origin'), '*')
+          assert.equal(res.getHeader('Vary'), undefined)
+
+          cors(options)(req, res, function(err2) {
+            assert.ifError(err)
+            assert.equal(res.getHeader('Access-Control-Allow-Origin'), null)
+            assert.equal(res.getHeader('Vary'), 'Origin')
+            return done();
+          });
+        });
+      });
+
       it('origin of false disables cors', function (done) {
         // arrange
         var req, res, next, options;


### PR DESCRIPTION
This fixes https://github.com/expressjs/cors/issues/167